### PR TITLE
Modal clear event refactored

### DIFF
--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -29,12 +29,13 @@ const Component: React.ForwardRefRenderFunction<ModalProps, ModalBaseProps> = ({
 
     const opened = () => onShow(true);
 
-    const closed = () => onShow(false);
+    const closed = () => {
+        onShow(false);
+        if (clear) clear();
+    }
 
     const outside = () => {
-        closed();
-
-        if (clear) clear();
+        closed(); 
     };
 
     useImperativeHandle(ref, () => ({


### PR DESCRIPTION
modal clear event will now get fired when the close icon/outside the modal is click 